### PR TITLE
chore(deps): patch remaining actionable npm advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3038,9 +3038,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.5.tgz",
-      "integrity": "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.10.tgz",
+      "integrity": "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3180,9 +3180,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -11887,9 +11887,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -13282,9 +13282,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -15354,15 +15354,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/refractor/node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/regenerate": {

--- a/package.json
+++ b/package.json
@@ -89,8 +89,14 @@
     "node": ">= 22.11.0"
   },
   "overrides": {
-    "@hono/node-server": "2.0.5",
+    "@hono/node-server": "2.0.10",
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "3.15.1"
+    },
     "fast-xml-parser": "5.7.0",
+    "js-yaml": "4.3.1",
+    "nanoid": "3.3.17",
+    "prismjs": "1.30.0",
     "react-syntax-highlighter": "$react-syntax-highlighter",
     "uuid": "11.1.1"
   },


### PR DESCRIPTION
## Summary

- pin nanoid 3.3.17 for GHSA-2v37-7h3g-55p8
- pin js-yaml 3.15.1 and 4.3.1 for GHSA-5p4m-2wfm-xmqj
- pin @hono/node-server 2.0.10 for GHSA-9mqv-5hh9-4cgg
- deduplicate PrismJS on 1.30.0 for GHSA-x7hr-w5r2-h6wg
- retain Hono 4.13.1 from merged PR #34

This resolves the five actionable alerts remaining after the Hono merge, for all eight originally patchable alerts across the two changes. Dependabot alerts #132 and #133 remain because image-size currently has no patched release; npm audit expands those two advisories through the Metro/Expo dependency chain.

## Validation

- npm dependency tree resolves every targeted package to its patched version
- 89 Jest suites / 501 tests pass
- ESLint passes with zero errors and four pre-existing warnings
- Android debug APK builds successfully for arm64-v8a only