### PR TITLE
fix: ignore a cached herdr socket from another session

### DIFF
--- a/packages/react-native-whip-ssh/rust/src/herdr_connection.rs
+++ b/packages/react-native-whip-ssh/rust/src/herdr_connection.rs
@@ -106,6 +106,8 @@ impl HerdrConnection {
         socket_path: Option<String>,
         cached_socket_path: Option<String>,
     ) -> Arc<Self> {
+        let cached_socket_path =
+            cached_socket_path.filter(|path| path.ends_with(&session_socket_suffix(&session_name)));
         let socket_from_cache = socket_path.is_none() && cached_socket_path.is_some();
         let resolved_socket = socket_path.or(cached_socket_path);
         let (lifecycle, _) = watch::channel(0);
@@ -278,12 +280,7 @@ impl HerdrConnection {
         if home.is_empty() {
             return Err(HerdrConnectionError::InvalidRemoteHome);
         }
-        let data_dir = if self.session_name.trim().is_empty() {
-            format!("{home}/.config/herdr")
-        } else {
-            format!("{home}/.config/herdr/sessions/{}", self.session_name.trim())
-        };
-        let socket = format!("{data_dir}/herdr.sock");
+        let socket = format!("{home}{}", session_socket_suffix(&self.session_name));
         let mut state = self.state.write();
         if state.revision != snapshot.revision {
             return Err(HerdrConnectionError::Stale);
@@ -501,6 +498,15 @@ fn connection_revision_is_current(connection: &Weak<HerdrConnection>, revision: 
         .is_some_and(|connection| connection.state.read().revision == revision)
 }
 
+fn session_socket_suffix(session_name: &str) -> String {
+    let session_name = session_name.trim();
+    if session_name.is_empty() {
+        "/.config/herdr/herdr.sock".to_owned()
+    } else {
+        format!("/.config/herdr/sessions/{session_name}/herdr.sock")
+    }
+}
+
 fn client_socket_path(api_socket: &str) -> String {
     api_socket
         .strip_suffix(".sock")
@@ -643,9 +649,48 @@ mod tests {
             "cached".to_owned(),
             String::new(),
             None,
-            Some("/cached.sock".to_owned()),
+            Some("/home/u/.config/herdr/herdr.sock".to_owned()),
         );
         assert!(cached.state.read().socket_from_cache);
+    }
+
+    #[test]
+    fn cached_socket_from_another_session_is_ignored() {
+        let named = |session: &str, cached: &str| {
+            HerdrConnection::new(
+                "cached".to_owned(),
+                session.to_owned(),
+                None,
+                Some(cached.to_owned()),
+            )
+        };
+
+        let switched = named("b", "/home/u/.config/herdr/sessions/a/herdr.sock");
+        assert_eq!(switched.resolved_socket_path(), None);
+        assert!(!switched.state.read().socket_from_cache);
+
+        let to_default = named("", "/home/u/.config/herdr/sessions/a/herdr.sock");
+        assert_eq!(to_default.resolved_socket_path(), None);
+        let to_named = named("a", "/home/u/.config/herdr/herdr.sock");
+        assert_eq!(to_named.resolved_socket_path(), None);
+
+        let unchanged = named("a", "/home/u/.config/herdr/sessions/a/herdr.sock");
+        assert_eq!(
+            unchanged.resolved_socket_path().as_deref(),
+            Some("/home/u/.config/herdr/sessions/a/herdr.sock")
+        );
+        assert!(unchanged.state.read().socket_from_cache);
+
+        let explicit = HerdrConnection::new(
+            "explicit".to_owned(),
+            "b".to_owned(),
+            Some("/run/herdr.sock".to_owned()),
+            Some("/home/u/.config/herdr/sessions/a/herdr.sock".to_owned()),
+        );
+        assert_eq!(
+            explicit.resolved_socket_path().as_deref(),
+            Some("/run/herdr.sock")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Outcome

Changing the session on an existing host profile had no effect: Whip kept
talking to the session the profile was first connected to, and the new
setting was silently ignored. It now connects to the session you asked for.

## Why

Each host profile persists the socket path it last resolved, and
`HerdrConnection::new` seeded that hint verbatim without checking which
session it belonged to. The hint is only dropped when a connect fails, so
after a session change the old session's server was still listening,
answered the readiness probe, and startup returned early — never reaching
`start_herdr_server_command`, the path that passes `--session`.

The socket is derived from the remote `$HOME` plus a fixed per-session
suffix, so the suffix alone identifies whose hint it is. A hint that does
not end with the current session's suffix is now rejected and resolution
runs again; `resolve_socket` shares the same helper so the two cannot
drift. An explicitly configured socket still wins, and a matching hint
keeps its fast path.

Stale hints need no migration: they are dropped in memory, and the correct
path is persisted after the first snapshot.

## Verification

Edited the session field of an existing host profile in the UI and
confirmed Whip now switches to that session. Unit tests cover the hint
rejection.

## Screenshots or recording

Not applicable — no UI change.
